### PR TITLE
Add mobile-friendly mode switcher for Claude Code

### DIFF
--- a/src/public/style.css
+++ b/src/public/style.css
@@ -1099,3 +1099,98 @@ body {
         height: 36px;
     }
 }
+
+/* Mode Switcher Styles */
+.mode-switcher {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    z-index: 1000;
+    display: none;
+}
+
+/* Show mode switcher on mobile devices */
+@media (max-width: 1024px) and (hover: none) and (pointer: coarse),
+       (max-width: 768px) {
+    .mode-switcher {
+        display: block;
+    }
+}
+
+.mode-switcher-btn {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 16px;
+    background-color: var(--bg-secondary);
+    color: var(--text-primary);
+    border: 2px solid var(--border);
+    border-radius: 50px;
+    font-size: 14px;
+    font-weight: 500;
+    font-family: var(--font-mono);
+    cursor: pointer;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    transition: all 0.3s ease;
+    min-width: 120px;
+    justify-content: center;
+}
+
+.mode-switcher-btn:hover {
+    background-color: var(--bg-tertiary);
+    border-color: var(--accent);
+    transform: translateY(-2px);
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.4);
+}
+
+.mode-switcher-btn:active {
+    transform: translateY(0);
+}
+
+.mode-switcher-btn.switching {
+    animation: modeSwitchPulse 0.3s ease;
+}
+
+@keyframes modeSwitchPulse {
+    0% {
+        transform: scale(1);
+    }
+    50% {
+        transform: scale(0.95);
+        background-color: var(--accent);
+    }
+    100% {
+        transform: scale(1);
+    }
+}
+
+.mode-switcher-btn svg {
+    width: 20px;
+    height: 20px;
+    stroke: var(--accent);
+    flex-shrink: 0;
+}
+
+.mode-switcher-btn span {
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+/* Ensure button meets accessibility guidelines */
+.mode-switcher-btn {
+    min-height: 44px;
+    min-width: 44px;
+}
+
+/* Add visual indicator for current mode */
+.mode-switcher-btn[data-mode="chat"] {
+    border-color: var(--success);
+}
+
+.mode-switcher-btn[data-mode="code"] {
+    border-color: var(--accent);
+}
+
+.mode-switcher-btn[data-mode="plan"] {
+    border-color: var(--warning);
+}


### PR DESCRIPTION
## Summary
- Implements a floating action button (FAB) for mobile devices to switch between Claude Code modes
- Addresses issue #4 where mobile users cannot use Shift+Tab keyboard shortcut
- Provides accessible, touch-friendly alternative for mode switching

## Changes
### JavaScript (app.js)
- Added mobile device detection using touch capability and user agent checks
- Implemented `showModeSwitcher()` to create floating button on mobile
- Added `switchMode()` function that cycles through chat/code/plan modes
- Sends ESC[Z (Shift+Tab) terminal sequence to trigger mode switch in Claude Code

### CSS (style.css)
- Added responsive styling for floating mode switcher button
- Positioned at bottom-right corner with proper z-index
- Includes hover effects, animations, and color-coded mode indicators
- Meets accessibility guidelines with 44x44px minimum touch target

## Testing
- Mobile detection works for iOS/Android devices and tablets
- Button only appears on touch-enabled devices
- Mode switching sends correct terminal sequence
- Visual feedback with animation and color changes
- Button is easily discoverable and accessible

## Screenshots
The mode switcher appears as a floating button on mobile devices:
- Chat mode: Green border
- Code mode: Blue border  
- Plan mode: Yellow border

## Fixes
Fixes #4

🤖 Generated with [Claude Code](https://claude.ai/code)