### PR TITLE
ci(release): make workflow unconditional on main; skip if tag exists

### DIFF
--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -8,7 +8,6 @@ jobs:
   release:
     name: Tag, Release, and Publish
     runs-on: ubuntu-latest
-    if: startsWith(github.event.head_commit.message, 'chore(release): v')
     permissions:
       contents: write
       packages: write
@@ -27,7 +26,19 @@ jobs:
         run: |
           echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
 
+      - name: Check if tag exists
+        id: check
+        run: |
+          git fetch --tags --force --quiet
+          if git rev-parse -q --verify "refs/tags/v${{ steps.pkg.outputs.version }}" >/dev/null; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Tag v${{ steps.pkg.outputs.version }} already exists. Skipping release."
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Create GitHub Release (also creates tag)
+        if: ${{ steps.check.outputs.exists == 'false' }}
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ steps.pkg.outputs.version }}
@@ -39,11 +50,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies
+        if: ${{ steps.check.outputs.exists == 'false' }}
         run: npm ci
 
       - name: Publish to npm
+        if: ${{ steps.check.outputs.exists == 'false' }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           npm publish --access public
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,7 @@ Main is protected. All releases must go through a pull request from a separate b
 Notes:
 - Never push directly to `main`. Branch protection will reject such pushes.
 - Ensure `secrets.NPM_TOKEN` is configured at the repository level for publishing.
+- The workflow runs on every merge to `main` and skips if a tag for the current `package.json` version already exists.
 
 ## License
 


### PR DESCRIPTION
- Release workflow now runs on every merge to main.\n- Adds tag-existence check (vX.Y.Z from package.json).\n- Only tags, creates release, and publishes when tag does not already exist.\n- CONTRIBUTING updated to reflect new behavior.\n\nThis avoids relying on specific commit messages and supports PR-only merges to main.