### PR TITLE
chore(release): v2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,3 +100,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.1.3] - Previous Release
 - Previous version baseline
+## [2.6.0] - 2025-08-29
+
+### Added
+- Assistant alias support across CLI, server, and UI.
+  - New CLI flags: `--claude-alias <name>` and `--codex-alias <name>`.
+  - New env vars: `CLAUDE_ALIAS`, `CODEX_ALIAS`.
+  - `/api/config` now returns `aliases` for the frontend.
+- UI now displays configured aliases in buttons, prompts, and messages.
+- Tests: added `test/server-alias.test.js` to validate server alias configuration.
+
+### Changed
+- Startup logs show configured aliases.
+- README updated with alias usage examples.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,7 +100,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.1.3] - Previous Release
 - Previous version baseline
-## [2.6.0] - 2025-08-29
+## [2.6.1] - 2025-08-29
 
 ### Added
 - Assistant alias support across CLI, server, and UI.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,30 @@ npx claude-code-web --https --cert /path/to/cert.pem --key /path/to/key.pem
 ```bash
 # Enable additional logging and debugging
 npx claude-code-web --dev
+
+### Assistant Aliases
+
+You can customize how the assistants are labeled in the UI (for example, to display "Alice" instead of "Claude" or "R2" instead of "Codex").
+
+- Flags:
+  - `--claude-alias <name>`: Set the display name for Claude (default: env `CLAUDE_ALIAS` or "Claude").
+  - `--codex-alias <name>`: Set the display name for Codex (default: env `CODEX_ALIAS` or "Codex").
+
+Examples:
+
+```
+npx claude-code-web --claude-alias Alice --codex-alias R2
+```
+
+Or via environment variables:
+
+```
+export CLAUDE_ALIAS=Alice
+export CODEX_ALIAS=R2
+npx claude-code-web
+```
+
+These aliases are for display purposes only; they do not change which underlying CLI is launched.
 ```
 
 ### Running from source

--- a/bin/cc-web.js
+++ b/bin/cc-web.js
@@ -11,7 +11,7 @@ const program = new Command();
 program
   .name('cc-web')
   .description('Web-based interface for Claude Code CLI')
-  .version('2.6.0')
+  .version('2.6.1')
   .option('-p, --port <number>', 'port to run the server on', '32352')
   .option('--no-open', 'do not automatically open browser')
   .option('--auth <token>', 'authentication token for secure access')

--- a/bin/cc-web.js
+++ b/bin/cc-web.js
@@ -11,7 +11,7 @@ const program = new Command();
 program
   .name('cc-web')
   .description('Web-based interface for Claude Code CLI')
-  .version('2.0.0')
+  .version('2.6.0')
   .option('-p, --port <number>', 'port to run the server on', '32352')
   .option('--no-open', 'do not automatically open browser')
   .option('--auth <token>', 'authentication token for secure access')
@@ -21,6 +21,8 @@ program
   .option('--key <path>', 'path to SSL private key file')
   .option('--dev', 'development mode with additional logging')
   .option('--plan <type>', 'subscription plan (pro, max5, max20)', 'max20')
+  .option('--claude-alias <name>', 'display alias for Claude (default: env CLAUDE_ALIAS or "Claude")')
+  .option('--codex-alias <name>', 'display alias for Codex (default: env CODEX_ALIAS or "Codex")')
   .option('--ngrok-auth-token <token>', 'ngrok auth token to open a public tunnel')
   .option('--ngrok-domain <domain>', 'ngrok reserved domain to use for the tunnel')
   .parse();
@@ -68,6 +70,9 @@ async function main() {
       key: options.key,
       dev: options.dev,
       plan: options.plan,
+      // UI aliases for assistants
+      claudeAlias: options.claudeAlias || process.env.CLAUDE_ALIAS || 'Claude',
+      codexAlias: options.codexAlias || process.env.CODEX_ALIAS || 'Codex',
       folderMode: true // Always use folder mode
     };
 
@@ -75,6 +80,7 @@ async function main() {
     console.log(`Port: ${port}`);
     console.log('Mode: Folder selection mode');
     console.log(`Plan: ${options.plan}`);
+    console.log(`Aliases: Claude → "${serverOptions.claudeAlias}", Codex → "${serverOptions.codexAlias}"`);
     
     // Display authentication status prominently
     if (noAuth) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-web",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Web-based interface for Claude Code CLI accessible via browser",
   "main": "src/server.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-web",
-  "version": "2.5.3",
+  "version": "2.6.0",
   "description": "Web-based interface for Claude Code CLI accessible via browser",
   "main": "src/server.js",
   "bin": {

--- a/src/public/session-manager.js
+++ b/src/public/session-manager.js
@@ -7,6 +7,13 @@ class SessionTabManager {
         this.notificationsEnabled = false;
         this.requestNotificationPermission();
     }
+
+    getAlias(kind) {
+        if (this.claudeInterface && typeof this.claudeInterface.getAlias === 'function') {
+            return this.claudeInterface.getAlias(kind);
+        }
+        return kind === 'codex' ? 'Codex' : 'Claude';
+    }
     
     requestNotificationPermission() {
         if ('Notification' in window) {
@@ -216,7 +223,7 @@ class SessionTabManager {
             promptDiv.innerHTML = `
                 <div style="margin-bottom: 10px;">
                     <strong>Enable Desktop Notifications?</strong><br>
-                    Get notified when Claude completes tasks in background tabs.
+                    Get notified when ${this.getAlias('claude')} completes tasks in background tabs.
                 </div>
                 <div style="display: flex; gap: 10px;">
                     <button id="enableNotifications" style="
@@ -853,7 +860,7 @@ class SessionTabManager {
                             
                             // Send notification that Claude appears to have finished
                             this.sendNotification(
-                                `✅ ${sessionName} - Claude appears finished`,
+                                `✅ ${sessionName} - ${this.getAlias('claude')} appears finished`,
                                 `No output for 90 seconds (worked for ${Math.round(duration / 1000)}s)`,
                                 sessionId
                             );

--- a/src/server.js
+++ b/src/server.js
@@ -44,6 +44,11 @@ class ClaudeCodeWebServer {
     this.startTime = Date.now(); // Track server start time
     // Commands directory (in user's home)
     this.commandsDir = path.join(os.homedir(), '.claude-code-web', 'commands');
+    // Assistant aliases (for UI display only)
+    this.aliases = {
+      claude: options.claudeAlias || process.env.CLAUDE_ALIAS || 'Claude',
+      codex: options.codexAlias || process.env.CODEX_ALIAS || 'Codex'
+    };
     
     this.setupExpress();
     this.loadPersistedSessions();
@@ -382,7 +387,8 @@ class ClaudeCodeWebServer {
       res.json({ 
         folderMode: this.folderMode,
         selectedWorkingDir: this.selectedWorkingDir,
-        baseFolder: this.baseFolder
+        baseFolder: this.baseFolder,
+        aliases: this.aliases
       });
     });
 

--- a/test/server-alias.test.js
+++ b/test/server-alias.test.js
@@ -1,0 +1,22 @@
+const assert = require('assert');
+const { ClaudeCodeWebServer } = require('../src/server');
+
+describe('Server Aliases', function() {
+  it('should set aliases from options', function() {
+    const server = new ClaudeCodeWebServer({
+      claudeAlias: 'Buddy',
+      codexAlias: 'Robo',
+      noAuth: true // avoid auth middleware complexity
+    });
+
+    assert.strictEqual(server.aliases.claude, 'Buddy');
+    assert.strictEqual(server.aliases.codex, 'Robo');
+  });
+
+  it('should default aliases when not provided', function() {
+    const server = new ClaudeCodeWebServer({ noAuth: true });
+    assert.ok(server.aliases.claude && server.aliases.claude.length > 0);
+    assert.ok(server.aliases.codex && server.aliases.codex.length > 0);
+  });
+});
+


### PR DESCRIPTION
### What
Release v2.6.1

### Highlights
- Assistant alias support across CLI, server, and UI.
  - New CLI flags: `--claude-alias <name>`, `--codex-alias <name>`
  - New env vars: `CLAUDE_ALIAS`, `CODEX_ALIAS`
  - `/api/config` now returns `aliases` for the frontend
- UI shows configured aliases in buttons, prompts, and messages
- README updated with alias usage examples
- Tests: add `test/server-alias.test.js`

### Notes
- Backwards compatible feature (MINOR bump).

Please review and merge. After merge, tag v2.6.1 already exists and a GitHub release will be available.
