### PR TITLE
Release v2.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,3 +206,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Notes
 - UI/UX change only; no server/CLI API changes.
+## [2.15.0] - 2025-09-13
+
+### Added
+- Drag a pane tab to the grid’s right edge to create a new split and move the tab (VS Code‑like “drag to split”).
+
+### Changed
+- Pane tab items are now draggable between splits; dropping on another split moves the tab there.
+- Pane Add Tab button opens a session picker menu consistently across panes.
+
+### Notes
+- UI‑only; no server/CLI changes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-code-web",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-code-web",
-      "version": "2.14.0",
+      "version": "2.15.0",
       "license": "MIT",
       "dependencies": {
         "@ngrok/ngrok": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-web",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "description": "Web-based interface for Claude Code CLI accessible via browser",
   "main": "src/server.js",
   "bin": {

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -184,21 +184,6 @@
                         </div>
                         <div class="tile-terminal" id="tileTerminal0"></div>
                     </div>
-                    <div class="resizer" data-index="0" title="Drag to resize"></div>
-                    <div class="tile-pane" data-index="1">
-                        <div class="tile-toolbar">
-                            <div class="pane-tabs" data-index="1"></div>
-                            <button class="pane-add" data-index="1" title="Add tab">
-                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
-                            </button>
-                            <select class="tile-session-select" data-index="1" style="display:none"></select>
-                            <div class="spacer"></div>
-                            <button class="tile-close" data-index="1" title="Close Pane">
-                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
-                            </button>
-                        </div>
-                        <div class="tile-terminal" id="tileTerminal1"></div>
-                    </div>
                 </div>
             </div>
         </main>


### PR DESCRIPTION
This PR releases v2.15.0.

Highlights:
- Drag pane tab to right edge to create a new split (drag-to-split)
- Move tabs between splits by dragging onto a different split
- Consistent Add Tab menu per pane

No API/CLI changes.
