### PR TITLE
chore(release): v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -258,3 +258,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Notes
 - UI‑only features; no server/CLI API changes.
+
+## [3.0.0] - 2025-09-13
+
+### Removed
+- Custom prompts dropdown UI ("/" button, commands list, and "Custom…" modal).
+- Server endpoints `GET /api/commands/list` and `GET /api/commands/content`.
+
+### Breaking Changes
+- The commands dropdown system and its APIs are no longer available. Any external automation calling `/api/commands/*` must be migrated to send content directly to the active session via WebSocket input.
+
+### Migration Notes
+- To send predefined prompts, store them in your own UI or scripts and paste/send directly to the terminal. The app will forward input to the active session as before.

--- a/bin/cc-web.js
+++ b/bin/cc-web.js
@@ -11,7 +11,7 @@ const program = new Command();
 program
   .name('cc-web')
   .description('Web-based interface for Claude Code CLI')
-  .version('2.6.1')
+  .version('3.0.0')
   .option('-p, --port <number>', 'port to run the server on', '32352')
   .option('--no-open', 'do not automatically open browser')
   .option('--auth <token>', 'authentication token for secure access')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-code-web",
-  "version": "2.18.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-code-web",
-      "version": "2.18.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@ngrok/ngrok": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-web",
-  "version": "2.18.0",
+  "version": "3.0.0",
   "description": "Web-based interface for Claude Code CLI accessible via browser",
   "main": "src/server.js",
   "bin": {


### PR DESCRIPTION
Release v3.0.0 (MAJOR)\n\n- Remove custom prompts dropdown and server endpoints (/api/commands/*)\n- Update bin CLI version banner to 3.0.0\n- Update CHANGELOG\n\nThis is a breaking UI/API change; see migration notes in CHANGELOG.