### PR TITLE
fix(ui): global tabs + pane stability

### DIFF
--- a/src/public/app.js
+++ b/src/public/app.js
@@ -73,7 +73,7 @@ class ClaudeCodeWebInterface {
         this.setupTerminal();
         this.setupUI();
         this.setupPlanDetector();
-        // Pane manager after UI exists (always-on multi-pane)
+        // Pane manager after UI exists (optional multi-pane)
         this.paneManager = new PaneManager(this);
         this.loadSettings();
         this.applyAliasesToUI();
@@ -85,10 +85,8 @@ class ClaudeCodeWebInterface {
         // Initialize the session tab manager and wait for sessions to load
         this.sessionTabManager = new SessionTabManager(this);
         await this.sessionTabManager.init();
-        // Always enable multi-pane mode and hide global tabs
-        if (this.paneManager && !this.paneManager.enabled) {
-            this.paneManager.enable();
-        }
+        // Respect user preference from storage; do not auto-enable panes by default
+        // PaneManager.restoreFromStorage() will enable if previously enabled.
         
         // Show mode switcher on mobile
         if (this.isMobile) {

--- a/src/public/style.css
+++ b/src/public/style.css
@@ -467,9 +467,7 @@ body {
 .tab-tile:hover { background: var(--bg-tertiary); color: var(--text-primary); }
 .tab-tile[disabled] { opacity: .5; cursor: not-allowed; }
 
-/* Always multi-pane: hide global tabs */
-.session-tabs-bar .tabs-section { display: none !important; }
-#tabOverflowWrapper { display: none !important; }
+/* Global tabs are visible; panes can be enabled optionally */
 
 .tab-new:hover {
     background-color: var(--bg-tertiary);


### PR DESCRIPTION
This PR addresses multiple UX regressions:

- Restore global tabs; panes are optional (not forced). 
- Do not auto-enable tiled mode on load; respect persisted state.
- Keep global tabs visible in tiled mode (VS Code-like: tabs target active pane).
- Pane "+" opens a session picker (Shift+click opens folder browser).
- Split-pane terminals now replay output buffer on join (render 'session_joined' output).
- Minor CSS cleanup: remove rule that hid tabs in tiled mode.

This resolves: 
- Single pane taking half width (already fixed in 3.0.3 overlay change).
- Switching tabs creating the impression of a new session (was showing empty because we didn't replay buffer).
- Closing a tab now deletes the session and removes it from all panes.
- New panes can attach to existing sessions via picker; sessions work immediately.
- Pane layout persists across refresh without forcing tiled mode.
