### PR TITLE
chore(release): v3.2.0 - Add Cursor Agent Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [3.2.0] - 2025-10-23
+
+### Added
+- Cursor Agent (`cursor-agent`) support as a third CLI option alongside Claude and Codex
+- New CLI flag: `--agent-alias <name>` to customize the display name for Cursor Agent (default: "Cursor")
+- New environment variable: `AGENT_ALIAS` for setting the agent alias
+- "Start Cursor" button in assistant selection UI (main overlay and per-pane overlays)
+- Full WebSocket message handling for `start_agent`, `agent_started`, and `agent_stopped` events
+- Agent session management in `AgentBridge` with automatic command detection
+
+### Changed
+- Updated startup logs to display all three assistant aliases (Claude, Codex, Agent)
+- Enhanced `/api/config` endpoint to include agent alias
+- Extended session management to support three concurrent agent types per session
+
+### Notes
+- Backwards-compatible feature addition; existing Claude and Codex functionality unchanged
+- Agent bridge searches for `cursor-agent` in standard paths (~/.cursor/local/cursor-agent, ~/.local/bin/cursor-agent, etc.)
+- No special CLI flags required for agent (unlike Claude's `--dangerously-skip-permissions` or Codex's bypass flag)
+
 ## [3.1.0] - 2025-09-15
 
 ### Added

--- a/bin/cc-web.js
+++ b/bin/cc-web.js
@@ -11,7 +11,7 @@ const program = new Command();
 program
   .name('cc-web')
   .description('Web-based interface for Claude Code CLI')
-  .version('3.1.0')
+  .version('3.2.0')
   .option('-p, --port <number>', 'port to run the server on', '32352')
   .option('--no-open', 'do not automatically open browser')
   .option('--auth <token>', 'authentication token for secure access')
@@ -23,6 +23,7 @@ program
   .option('--plan <type>', 'subscription plan (pro, max5, max20)', 'max20')
   .option('--claude-alias <name>', 'display alias for Claude (default: env CLAUDE_ALIAS or "Claude")')
   .option('--codex-alias <name>', 'display alias for Codex (default: env CODEX_ALIAS or "Codex")')
+  .option('--agent-alias <name>', 'display alias for Agent (default: env AGENT_ALIAS or "Cursor")')
   .option('--ngrok-auth-token <token>', 'ngrok auth token to open a public tunnel')
   .option('--ngrok-domain <domain>', 'ngrok reserved domain to use for the tunnel')
   .parse();
@@ -73,6 +74,7 @@ async function main() {
       // UI aliases for assistants
       claudeAlias: options.claudeAlias || process.env.CLAUDE_ALIAS || 'Claude',
       codexAlias: options.codexAlias || process.env.CODEX_ALIAS || 'Codex',
+      agentAlias: options.agentAlias || process.env.AGENT_ALIAS || 'Cursor',
       folderMode: true // Always use folder mode
     };
 
@@ -80,7 +82,7 @@ async function main() {
     console.log(`Port: ${port}`);
     console.log('Mode: Folder selection mode');
     console.log(`Plan: ${options.plan}`);
-    console.log(`Aliases: Claude → "${serverOptions.claudeAlias}", Codex → "${serverOptions.codexAlias}"`);
+    console.log(`Aliases: Claude → "${serverOptions.claudeAlias}", Codex → "${serverOptions.codexAlias}", Agent → "${serverOptions.agentAlias}"`);
     
     // Display authentication status prominently
     if (noAuth) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-web",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Web-based interface for Claude Code CLI accessible via browser",
   "main": "src/server.js",
   "bin": {

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -180,6 +180,7 @@
                         <button id="dangerousSkipBtn" class="btn btn-danger" title="Dangerously skip permissions. Use with caution.">Dangerous Claude</button>
                         <button id="startCodexBtn" class="btn btn-primary">Start Codex</button>
                         <button id="dangerousCodexBtn" class="btn btn-danger" title="Bypass approvals and sandbox. Use with caution.">Dangerous Codex</button>
+                        <button id="startAgentBtn" class="btn btn-primary">Start Cursor</button>
                     </div>
                 </div>
                 <div class="error-message" id="errorMessage" style="display: none;">

--- a/src/public/panes.js
+++ b/src/public/panes.js
@@ -121,7 +121,7 @@ class ClaudePane {
   }
 
   showStartOverlay() {
-    // Build a minimal per-pane start overlay (Claude/Codex)
+    // Build a minimal per-pane start overlay (Claude/Codex/Agent)
     if (!this.container) return;
     this.hideStartOverlay();
     const ov = document.createElement('div');
@@ -135,6 +135,7 @@ class ClaudePane {
           <button class="btn btn-danger" data-kind="claude" data-danger>Dangerous ${this.app?.getAlias?.('claude') || 'Claude'}</button>
           <button class="btn btn-primary" data-kind="codex">Start ${this.app?.getAlias?.('codex') || 'Codex'}</button>
           <button class="btn btn-danger" data-kind="codex" data-danger>Dangerous ${this.app?.getAlias?.('codex') || 'Codex'}</button>
+          <button class="btn btn-primary" data-kind="agent">Start ${this.app?.getAlias?.('agent') || 'Cursor'}</button>
         </div>
       </div>`;
     ov.querySelectorAll('button').forEach(btn => {
@@ -157,7 +158,9 @@ class ClaudePane {
 
   startAssistant(kind = 'claude', options = {}) {
     if (!this.socket || this.socket.readyState !== WebSocket.OPEN) return;
-    const type = kind === 'codex' ? 'start_codex' : 'start_claude';
+    let type = 'start_claude';
+    if (kind === 'codex') type = 'start_codex';
+    else if (kind === 'agent') type = 'start_agent';
     this.socket.send(JSON.stringify({ type, options }));
     this.hideStartOverlay();
   }


### PR DESCRIPTION
## Release v3.2.0

This PR adds **cursor-agent** as a third CLI option alongside Claude and Codex.

### 🎯 Changes

- Add `AgentBridge` for managing cursor-agent sessions
- Add `--agent-alias` CLI flag and `AGENT_ALIAS` environment variable  
- Add "Start Cursor" button to UI overlays
- Add WebSocket handlers for `agent_started`/`agent_stopped` events
- Update session management for three agent types

### ✅ Checklist

- [x] Version bumped to 3.2.0 in package.json and bin/cc-web.js
- [x] CHANGELOG.md updated with release notes
- [x] All tests passing
- [x] No linter errors
- [x] Backwards compatible (MINOR version bump)
- [x] Tag v3.2.0 created and pushed
- [x] GitHub release created

### 📝 Release Notes

See full release notes: https://github.com/vultuk/claude-code-web/releases/tag/v3.2.0

---

**Ready to merge** ✅