### PR TITLE
chore(release): v3.2.1 - Fix cursor-agent command name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.2.1] - 2025-10-23
+
+### Fixed
+- Corrected agent command from `claude-agent` to `cursor-agent` in AgentBridge
+- Updated command search paths to use `~/.cursor/` instead of `~/.agent/`
+
 ## [3.2.0] - 2025-10-23
 
 ### Added

--- a/bin/cc-web.js
+++ b/bin/cc-web.js
@@ -11,7 +11,7 @@ const program = new Command();
 program
   .name('cc-web')
   .description('Web-based interface for Claude Code CLI')
-  .version('3.2.0')
+  .version('3.2.1')
   .option('-p, --port <number>', 'port to run the server on', '32352')
   .option('--no-open', 'do not automatically open browser')
   .option('--auth <token>', 'authentication token for secure access')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-web",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Web-based interface for Claude Code CLI accessible via browser",
   "main": "src/server.js",
   "bin": {


### PR DESCRIPTION
## Release v3.2.1 - Critical Patch

This PR fixes the agent command name that was incorrectly set in v3.2.0.

### 🐛 Bug Fixes

- Fixed agent command from `claude-agent` to `cursor-agent`
- Updated search paths to `~/.cursor/` directory

### 📝 Context

In v3.2.0, the agent command was mistakenly named `claude-agent` instead of `cursor-agent`. This patch corrects that error.

---

**Ready to merge** ✅