### PR TITLE
fix: Make xterm scrollbar clickable

### DIFF
--- a/src/public/style.css
+++ b/src/public/style.css
@@ -1230,6 +1230,7 @@ body {
     background-color: transparent !important;
     overflow-y: auto !important;
     overflow-x: hidden !important;
+    z-index: 1 !important;
 }
 
 .xterm .xterm-screen {
@@ -1248,8 +1249,8 @@ body {
 
 /* Fix scrollbar extending beyond viewport */
 .xterm-viewport::-webkit-scrollbar {
-    width: 10px;
-    height: 10px;
+    width: 14px;
+    height: 14px;
 }
 
 .xterm-viewport::-webkit-scrollbar-track {
@@ -1257,12 +1258,14 @@ body {
 }
 
 .xterm-viewport::-webkit-scrollbar-thumb {
-    background: var(--border);
-    border-radius: 5px;
+    background: #555;
+    border-radius: 7px;
+    border: 2px solid var(--bg-secondary);
+    min-height: 40px;
 }
 
 .xterm-viewport::-webkit-scrollbar-thumb:hover {
-    background: var(--border-hover);
+    background: #777;
 }
 
 /* Folder Browser Modal */


### PR DESCRIPTION
## Summary
Fix the xterm scrollbar being unclickable due to the canvas element covering it.

## Problem
Users cannot click or drag the terminal scrollbar because the `xterm-screen` canvas element is positioned on top of `xterm-viewport` which contains the scrollbar. Clicking on the scrollbar area results in text selection instead of scrolling.

This is a known xterm.js issue:
- https://github.com/xtermjs/xterm.js/issues/512
- https://github.com/xtermjs/xterm.js/issues/1284
- https://github.com/xtermjs/xterm.js/issues/1751

## Solution
- Add `z-index: 1` to `.xterm-viewport` to bring the scrollbar above the canvas layer
- Widen scrollbar from 10px to 14px for easier grabbing
- Improve scrollbar thumb visibility with better contrast colors
- Add min-height to scrollbar thumb for consistent grabbable area

## Test plan
- [x] Tested in Chrome on Windows - scrollbar is now clickable and draggable
- [ ] Should be tested in Firefox and Safari

🤖 Generated with [Claude Code](https://claude.ai/code)