### PR TITLE
feat: Add --cwd option to specify working directory

### DIFF
--- a/bin/cc-web.js
+++ b/bin/cc-web.js
@@ -20,6 +20,7 @@ program
   .option('--cert <path>', 'path to SSL certificate file')
   .option('--key <path>', 'path to SSL private key file')
   .option('--dev', 'development mode with additional logging')
+  .option('--cwd <path>', 'working directory for Claude sessions (default: current directory)')
   .option('--plan <type>', 'subscription plan (pro, max5, max20)', 'max20')
   .option('--claude-alias <name>', 'display alias for Claude (default: env CLAUDE_ALIAS or "Claude")')
   .option('--codex-alias <name>', 'display alias for Codex (default: env CODEX_ALIAS or "Codex")')
@@ -62,6 +63,22 @@ async function main() {
       }
     }
 
+    // Resolve and validate working directory if provided
+    let cwd = process.cwd();
+    if (options.cwd) {
+      const resolvedCwd = path.resolve(options.cwd);
+      const fs = require('fs');
+      if (!fs.existsSync(resolvedCwd)) {
+        console.error(`Error: Working directory does not exist: ${resolvedCwd}`);
+        process.exit(1);
+      }
+      if (!fs.statSync(resolvedCwd).isDirectory()) {
+        console.error(`Error: Path is not a directory: ${resolvedCwd}`);
+        process.exit(1);
+      }
+      cwd = resolvedCwd;
+    }
+
     const serverOptions = {
       port,
       auth: authToken,
@@ -70,6 +87,7 @@ async function main() {
       cert: options.cert,
       key: options.key,
       dev: options.dev,
+      cwd: cwd,
       plan: options.plan,
       // UI aliases for assistants
       claudeAlias: options.claudeAlias || process.env.CLAUDE_ALIAS || 'Claude',
@@ -80,7 +98,7 @@ async function main() {
 
     console.log('Starting Claude Code Web Interface...');
     console.log(`Port: ${port}`);
-    console.log('Mode: Folder selection mode');
+    console.log(`Working directory: ${cwd}`);
     console.log(`Plan: ${options.plan}`);
     console.log(`Aliases: Claude → "${serverOptions.claudeAlias}", Codex → "${serverOptions.codexAlias}", Agent → "${serverOptions.agentAlias}"`);
     


### PR DESCRIPTION
## Summary
- Add `--cwd <path>` command-line option to specify the working directory for Claude sessions
- Validates that the path exists and is a directory before starting
- Updates startup log to show the configured working directory

## Use Case
Useful when running cc-web from a different location than where you want Claude to work, or when you want to explicitly set the working directory regardless of where the command is run from.

## Usage
```bash
cc-web --cwd /path/to/project
```

## Test plan
- [ ] Run `cc-web --cwd /some/valid/path` and verify it starts with that directory
- [ ] Run `cc-web --cwd /nonexistent/path` and verify it exits with error
- [ ] Run `cc-web --cwd /path/to/file` (not a directory) and verify it exits with error
- [ ] Run `cc-web` without --cwd and verify it uses current directory (existing behavior)

🤖 Generated with [Claude Code](https://claude.ai/code)